### PR TITLE
Updates to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "minimist": "*",
     "mkdir-recursive": "*",
     "morgan": "^1.9.0",
-    "node-phantom": "*",
     "nodemon": "^1.14.12",
     "primordial": "*",
     "puppeteer": "*",
@@ -30,7 +29,6 @@
     "simhash": "*",
     "stackjs": "^0.1.0",
     "validator": "*",
-    "webshot": "*",
     "write-json-file": "^2.3.0"
   }
 }

--- a/tmvis.js
+++ b/tmvis.js
@@ -52,8 +52,8 @@ var path = require('path');
 var validator = require('validator');
 //var underscore = require('underscore');
 
-var webshot = require('webshot'); // PhantomJS wrapper
-
+//var webshot = require('webshot'); // PhantomJS wrapper
+var webshot = null;
 var argv = require('minimist')(process.argv.slice(2));
 
 var mementoFramework = require('./lib/mementoFramework.js');


### PR DESCRIPTION
- Got rid of dependencies not being used from package.json

- Node v12 is now the LTS version and this was breaking the program because a deprecated version of graceful-fs(v3) was being used by the webshot dependency. This dependency was used along with PhantomJS and after we switched to puppeteer, webshot and phantom dependencies are unused.