### PR TITLE
Fixed bug

### DIFF
--- a/tmvis.js
+++ b/tmvis.js
@@ -1840,10 +1840,7 @@ TimeMap.prototype.createScreenshotForMementoWithPuppeteer = function (curCookieC
   try {
     fs.openSync(
       path.join(__dirname + '/'+screenshotsLocation + memento.screenshotURI),
-      'r', function (e, r) {
-        ConsoleLogIfRequired(e);
-        ConsoleLogIfRequired(r);
-      });
+      'r');
 
     constructSSE(memento.screenshotURI + ' already exists...',curCookieClientId);
     ConsoleLogIfRequired(memento.screenshotURI + ' already exists...continuing',curCookieClientId);


### PR DESCRIPTION
- Existing screenshots are retaken every time summary page loads no matter what.

- New NodeJS version changed the fs.openSync() function parameters and function(e,r) [erased function below] was being sent as a parameter for mode.

- Mode parameter in openSync() is expected to be an octal string. A default value is assigned if this parameter isn't given.

- This function call fails hence the catch block executes and screenshot gets retaken every time.